### PR TITLE
chore: add changeset for tsdown build migration

### DIFF
--- a/.changeset/tsdown-build-migration.md
+++ b/.changeset/tsdown-build-migration.md
@@ -1,0 +1,18 @@
+---
+"@macalinao/codama-instruction-accounts-dedupe-visitor": patch
+"@macalinao/codama-nodes-from-anchor-x": patch
+"@macalinao/codama-renderers-js-esm": patch
+"@macalinao/codama-renderers-markdown": patch
+"@macalinao/coda-visitors": patch
+"@macalinao/clients-kamino-lending": patch
+"@macalinao/clients-meteora-damm-v2": patch
+"@macalinao/clients-orca-whirlpools": patch
+"@macalinao/clients-quarry": patch
+"@macalinao/clients-spl-governance": patch
+"@macalinao/clients-spl-stake-pool": patch
+"@macalinao/clients-token-metadata": patch
+"@macalinao/clients-tribeca": patch
+"@macalinao/clients-voter-stake-registry": patch
+---
+
+Migrate the package build from `tsc` to [tsdown](https://tsdown.dev). Builds now resolve the shared root `tsdown.config.ts` automatically and emit ESM with type declarations, sourcemaps, and declaration maps (unbundled, preserving source structure). No public API changes.


### PR DESCRIPTION
## Summary

Adds the missing changeset for the tsdown build migration (#102, `bf7f499`).

That PR migrated all packages from `tsc` to [tsdown](https://tsdown.dev) but landed without a changeset. Release #103 happened to ship 6 packages (`coda`, `create-coda`, the `mpl-*` clients, `codama-rename-visitor`) for unrelated reasons — and since tsdown was already on `master` at that point, those 6 shipped with tsdown builds. The remaining **14 publishable packages** still have their tsdown build change sitting on `master` unreleased.

This changeset gives those 14 packages a `patch` bump so their next publish ships the tsdown-built artifacts.

## Packages bumped (patch)

- `@macalinao/coda-visitors`
- `@macalinao/codama-instruction-accounts-dedupe-visitor`
- `@macalinao/codama-nodes-from-anchor-x`
- `@macalinao/codama-renderers-js-esm`
- `@macalinao/codama-renderers-markdown`
- `@macalinao/clients-kamino-lending`
- `@macalinao/clients-meteora-damm-v2`
- `@macalinao/clients-orca-whirlpools`
- `@macalinao/clients-quarry`
- `@macalinao/clients-spl-governance`
- `@macalinao/clients-spl-stake-pool`
- `@macalinao/clients-token-metadata`
- `@macalinao/clients-tribeca`
- `@macalinao/clients-voter-stake-registry`