### PR TITLE
feat(token-metadata): derive collection PDAs as instruction account defaults

### DIFF
--- a/.changeset/token-metadata-collection-defaults.md
+++ b/.changeset/token-metadata-collection-defaults.md
@@ -1,0 +1,12 @@
+---
+"@macalinao/clients-token-metadata": minor
+---
+
+Derive collection PDAs as instruction account defaults for the collection
+verification instructions. The collection Metadata (`collection`) and master
+edition (`collectionMasterEditionAccount`) accounts are now resolved
+automatically from the required `collectionMint` across `verifyCollection`,
+`unverifyCollection`, `setAndVerifyCollection`, `verifySizedCollectionItem`,
+`unverifySizedCollectionItem`, and `setAndVerifySizedCollectionItem`, and the
+`collectionMetadata` account is resolved for `setCollectionSize` and
+`bubblegumSetCollectionSize`.

--- a/clients/token-metadata/coda.config.ts
+++ b/clients/token-metadata/coda.config.ts
@@ -142,6 +142,25 @@ const MASTER_EDITION_AS_EDITION_INSTRUCTIONS = [
 // but their `token` account is optional and so cannot seed the PDA.)
 const TOKEN_RECORD_INSTRUCTIONS = ["mint", "lock", "unlock", "migrate"];
 
+// Legacy collection (un)verification instructions. Each takes a required
+// `collectionMint`, so the collection's Metadata (`collection`) and master
+// edition (`collectionMasterEditionAccount`) accounts are fully derivable.
+const COLLECTION_VERIFY_INSTRUCTIONS = [
+  "verifyCollection",
+  "unverifyCollection",
+  "setAndVerifyCollection",
+  "verifySizedCollectionItem",
+  "unverifySizedCollectionItem",
+  "setAndVerifySizedCollectionItem",
+];
+
+// Instructions whose `collectionMetadata` account is the Metadata PDA of the
+// required `collectionMint`.
+const COLLECTION_METADATA_INSTRUCTIONS = [
+  "setCollectionSize",
+  "bubblegumSetCollectionSize",
+];
+
 const metadataPdaOf = (mintAccount: string) =>
   pdaValueNode(pdaLinkNode("metadata"), [
     pdaSeedValueNode("programId", TOKEN_METADATA_PROGRAM_VALUE_NODE),
@@ -219,6 +238,28 @@ export default defineConfig({
       account: "destinationTokenRecord",
       defaultValue: tokenRecordPdaOf("mint", "destination"),
     },
+
+    // Legacy collection verification: derive the collection's Metadata and
+    // master edition accounts from the required `collectionMint`.
+    ...COLLECTION_VERIFY_INSTRUCTIONS.flatMap((instruction) => [
+      {
+        instruction,
+        account: "collection",
+        defaultValue: metadataPdaOf("collectionMint"),
+      },
+      {
+        instruction,
+        account: "collectionMasterEditionAccount",
+        defaultValue: masterEditionPdaOf("collectionMint"),
+      },
+    ]),
+
+    // `collectionMetadata` = Metadata PDA of the required `collectionMint`.
+    ...COLLECTION_METADATA_INSTRUCTIONS.map((instruction) => ({
+      instruction,
+      account: "collectionMetadata",
+      defaultValue: metadataPdaOf("collectionMint"),
+    })),
   ],
   visitors: [
     updateAccountsVisitor({

--- a/clients/token-metadata/src/generated/accounts/metadata.ts
+++ b/clients/token-metadata/src/generated/accounts/metadata.ts
@@ -36,8 +36,7 @@ import {
   type Option,
   type OptionOrNullable,
 } from "@solana/kit";
-import type { MetadataSeeds } from "../pdas/index.js";
-import { findMetadataPda } from "../pdas/index.js";
+import { findMetadataPda, type MetadataSeeds } from "../pdas/index.js";
 import {
   getCollectionDecoder,
   getCollectionDetailsDecoder,

--- a/clients/token-metadata/src/generated/instructions/bubblegumSetCollectionSize.ts
+++ b/clients/token-metadata/src/generated/instructions/bubblegumSetCollectionSize.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  address,
   combineCodec,
   getStructDecoder,
   getStructEncoder,
@@ -32,8 +33,10 @@ import {
 } from "@solana/kit";
 import {
   getAccountMetaFactory,
+  getAddressFromResolvedInstructionAccount,
   type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findMetadataPda } from "../pdas/index.js";
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "../programs/index.js";
 import {
   getSetCollectionSizeArgsDecoder,
@@ -125,6 +128,121 @@ export function getBubblegumSetCollectionSizeInstructionDataCodec(): FixedSizeCo
     getBubblegumSetCollectionSizeInstructionDataEncoder(),
     getBubblegumSetCollectionSizeInstructionDataDecoder(),
   );
+}
+
+export type BubblegumSetCollectionSizeAsyncInput<
+  TAccountCollectionMetadata extends string = string,
+  TAccountCollectionAuthority extends string = string,
+  TAccountCollectionMint extends string = string,
+  TAccountBubblegumSigner extends string = string,
+  TAccountCollectionAuthorityRecord extends string = string,
+> = {
+  /** Collection Metadata account */
+  collectionMetadata?: Address<TAccountCollectionMetadata>;
+  /** Collection Update authority */
+  collectionAuthority: TransactionSigner<TAccountCollectionAuthority>;
+  /** Mint of the Collection */
+  collectionMint: Address<TAccountCollectionMint>;
+  /** Signing PDA of Bubblegum program */
+  bubblegumSigner: TransactionSigner<TAccountBubblegumSigner>;
+  /** Collection Authority Record PDA */
+  collectionAuthorityRecord?: Address<TAccountCollectionAuthorityRecord>;
+  setCollectionSizeArgs: BubblegumSetCollectionSizeInstructionDataArgs["setCollectionSizeArgs"];
+};
+
+export async function getBubblegumSetCollectionSizeInstructionAsync<
+  TAccountCollectionMetadata extends string,
+  TAccountCollectionAuthority extends string,
+  TAccountCollectionMint extends string,
+  TAccountBubblegumSigner extends string,
+  TAccountCollectionAuthorityRecord extends string,
+  TProgramAddress extends Address = typeof TOKEN_METADATA_PROGRAM_ADDRESS,
+>(
+  input: BubblegumSetCollectionSizeAsyncInput<
+    TAccountCollectionMetadata,
+    TAccountCollectionAuthority,
+    TAccountCollectionMint,
+    TAccountBubblegumSigner,
+    TAccountCollectionAuthorityRecord
+  >,
+  config?: { programAddress?: TProgramAddress },
+): Promise<
+  BubblegumSetCollectionSizeInstruction<
+    TProgramAddress,
+    TAccountCollectionMetadata,
+    TAccountCollectionAuthority,
+    TAccountCollectionMint,
+    TAccountBubblegumSigner,
+    TAccountCollectionAuthorityRecord
+  >
+> {
+  // Program address.
+  const programAddress =
+    config?.programAddress ?? TOKEN_METADATA_PROGRAM_ADDRESS;
+
+  // Original accounts.
+  const originalAccounts = {
+    collectionMetadata: {
+      value: input.collectionMetadata ?? null,
+      isWritable: true,
+    },
+    collectionAuthority: {
+      value: input.collectionAuthority ?? null,
+      isWritable: false,
+    },
+    collectionMint: { value: input.collectionMint ?? null, isWritable: false },
+    bubblegumSigner: {
+      value: input.bubblegumSigner ?? null,
+      isWritable: false,
+    },
+    collectionAuthorityRecord: {
+      value: input.collectionAuthorityRecord ?? null,
+      isWritable: false,
+    },
+  };
+  const accounts = originalAccounts as Record<
+    keyof typeof originalAccounts,
+    ResolvedInstructionAccount
+  >;
+
+  // Original args.
+  const args = { ...input };
+
+  // Resolve default values.
+  if (!accounts.collectionMetadata.value) {
+    accounts.collectionMetadata.value = await findMetadataPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+
+  const getAccountMeta = getAccountMetaFactory(programAddress, "omitted");
+  return Object.freeze({
+    accounts: [
+      getAccountMeta("collectionMetadata", accounts.collectionMetadata),
+      getAccountMeta("collectionAuthority", accounts.collectionAuthority),
+      getAccountMeta("collectionMint", accounts.collectionMint),
+      getAccountMeta("bubblegumSigner", accounts.bubblegumSigner),
+      getAccountMeta(
+        "collectionAuthorityRecord",
+        accounts.collectionAuthorityRecord,
+      ),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
+    data: getBubblegumSetCollectionSizeInstructionDataEncoder().encode(
+      args as BubblegumSetCollectionSizeInstructionDataArgs,
+    ),
+    programAddress,
+  } as BubblegumSetCollectionSizeInstruction<
+    TProgramAddress,
+    TAccountCollectionMetadata,
+    TAccountCollectionAuthority,
+    TAccountCollectionMint,
+    TAccountBubblegumSigner,
+    TAccountCollectionAuthorityRecord
+  >);
 }
 
 export type BubblegumSetCollectionSizeInput<

--- a/clients/token-metadata/src/generated/instructions/setAndVerifyCollection.ts
+++ b/clients/token-metadata/src/generated/instructions/setAndVerifyCollection.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  address,
   combineCodec,
   getStructDecoder,
   getStructEncoder,
@@ -32,8 +33,10 @@ import {
 } from "@solana/kit";
 import {
   getAccountMetaFactory,
+  getAddressFromResolvedInstructionAccount,
   type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findMasterEditionPda, findMetadataPda } from "../pdas/index.js";
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "../programs/index.js";
 
 export const SET_AND_VERIFY_COLLECTION_DISCRIMINATOR = 25;
@@ -121,6 +124,154 @@ export function getSetAndVerifyCollectionInstructionDataCodec(): FixedSizeCodec<
     getSetAndVerifyCollectionInstructionDataEncoder(),
     getSetAndVerifyCollectionInstructionDataDecoder(),
   );
+}
+
+export type SetAndVerifyCollectionAsyncInput<
+  TAccountMetadata extends string = string,
+  TAccountCollectionAuthority extends string = string,
+  TAccountPayer extends string = string,
+  TAccountUpdateAuthority extends string = string,
+  TAccountCollectionMint extends string = string,
+  TAccountCollection extends string = string,
+  TAccountCollectionMasterEditionAccount extends string = string,
+  TAccountCollectionAuthorityRecord extends string = string,
+> = {
+  /** Metadata account */
+  metadata: Address<TAccountMetadata>;
+  /** Collection Update authority */
+  collectionAuthority: TransactionSigner<TAccountCollectionAuthority>;
+  /** Payer */
+  payer: TransactionSigner<TAccountPayer>;
+  /** Update Authority of Collection NFT and NFT */
+  updateAuthority: Address<TAccountUpdateAuthority>;
+  /** Mint of the Collection */
+  collectionMint: Address<TAccountCollectionMint>;
+  /** Metadata Account of the Collection */
+  collection?: Address<TAccountCollection>;
+  /** MasterEdition2 Account of the Collection Token */
+  collectionMasterEditionAccount?: Address<TAccountCollectionMasterEditionAccount>;
+  /** Collection Authority Record PDA */
+  collectionAuthorityRecord?: Address<TAccountCollectionAuthorityRecord>;
+};
+
+export async function getSetAndVerifyCollectionInstructionAsync<
+  TAccountMetadata extends string,
+  TAccountCollectionAuthority extends string,
+  TAccountPayer extends string,
+  TAccountUpdateAuthority extends string,
+  TAccountCollectionMint extends string,
+  TAccountCollection extends string,
+  TAccountCollectionMasterEditionAccount extends string,
+  TAccountCollectionAuthorityRecord extends string,
+  TProgramAddress extends Address = typeof TOKEN_METADATA_PROGRAM_ADDRESS,
+>(
+  input: SetAndVerifyCollectionAsyncInput<
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountUpdateAuthority,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >,
+  config?: { programAddress?: TProgramAddress },
+): Promise<
+  SetAndVerifyCollectionInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountUpdateAuthority,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >
+> {
+  // Program address.
+  const programAddress =
+    config?.programAddress ?? TOKEN_METADATA_PROGRAM_ADDRESS;
+
+  // Original accounts.
+  const originalAccounts = {
+    metadata: { value: input.metadata ?? null, isWritable: true },
+    collectionAuthority: {
+      value: input.collectionAuthority ?? null,
+      isWritable: true,
+    },
+    payer: { value: input.payer ?? null, isWritable: true },
+    updateAuthority: {
+      value: input.updateAuthority ?? null,
+      isWritable: false,
+    },
+    collectionMint: { value: input.collectionMint ?? null, isWritable: false },
+    collection: { value: input.collection ?? null, isWritable: false },
+    collectionMasterEditionAccount: {
+      value: input.collectionMasterEditionAccount ?? null,
+      isWritable: false,
+    },
+    collectionAuthorityRecord: {
+      value: input.collectionAuthorityRecord ?? null,
+      isWritable: false,
+    },
+  };
+  const accounts = originalAccounts as Record<
+    keyof typeof originalAccounts,
+    ResolvedInstructionAccount
+  >;
+
+  // Resolve default values.
+  if (!accounts.collection.value) {
+    accounts.collection.value = await findMetadataPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+  if (!accounts.collectionMasterEditionAccount.value) {
+    accounts.collectionMasterEditionAccount.value = await findMasterEditionPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+
+  const getAccountMeta = getAccountMetaFactory(programAddress, "omitted");
+  return Object.freeze({
+    accounts: [
+      getAccountMeta("metadata", accounts.metadata),
+      getAccountMeta("collectionAuthority", accounts.collectionAuthority),
+      getAccountMeta("payer", accounts.payer),
+      getAccountMeta("updateAuthority", accounts.updateAuthority),
+      getAccountMeta("collectionMint", accounts.collectionMint),
+      getAccountMeta("collection", accounts.collection),
+      getAccountMeta(
+        "collectionMasterEditionAccount",
+        accounts.collectionMasterEditionAccount,
+      ),
+      getAccountMeta(
+        "collectionAuthorityRecord",
+        accounts.collectionAuthorityRecord,
+      ),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
+    data: getSetAndVerifyCollectionInstructionDataEncoder().encode({}),
+    programAddress,
+  } as SetAndVerifyCollectionInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountUpdateAuthority,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >);
 }
 
 export type SetAndVerifyCollectionInput<

--- a/clients/token-metadata/src/generated/instructions/setAndVerifySizedCollectionItem.ts
+++ b/clients/token-metadata/src/generated/instructions/setAndVerifySizedCollectionItem.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  address,
   combineCodec,
   getStructDecoder,
   getStructEncoder,
@@ -33,8 +34,10 @@ import {
 } from "@solana/kit";
 import {
   getAccountMetaFactory,
+  getAddressFromResolvedInstructionAccount,
   type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findMasterEditionPda, findMetadataPda } from "../pdas/index.js";
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "../programs/index.js";
 
 export const SET_AND_VERIFY_SIZED_COLLECTION_ITEM_DISCRIMINATOR = 32;
@@ -126,6 +129,154 @@ export function getSetAndVerifySizedCollectionItemInstructionDataCodec(): FixedS
     getSetAndVerifySizedCollectionItemInstructionDataEncoder(),
     getSetAndVerifySizedCollectionItemInstructionDataDecoder(),
   );
+}
+
+export type SetAndVerifySizedCollectionItemAsyncInput<
+  TAccountMetadata extends string = string,
+  TAccountCollectionAuthority extends string = string,
+  TAccountPayer extends string = string,
+  TAccountUpdateAuthority extends string = string,
+  TAccountCollectionMint extends string = string,
+  TAccountCollection extends string = string,
+  TAccountCollectionMasterEditionAccount extends string = string,
+  TAccountCollectionAuthorityRecord extends string = string,
+> = {
+  /** Metadata account */
+  metadata: Address<TAccountMetadata>;
+  /** Collection Update authority */
+  collectionAuthority: TransactionSigner<TAccountCollectionAuthority>;
+  /** payer */
+  payer: TransactionSigner<TAccountPayer>;
+  /** Update Authority of Collection NFT and NFT */
+  updateAuthority: Address<TAccountUpdateAuthority>;
+  /** Mint of the Collection */
+  collectionMint: Address<TAccountCollectionMint>;
+  /** Metadata Account of the Collection */
+  collection?: Address<TAccountCollection>;
+  /** MasterEdition2 Account of the Collection Token */
+  collectionMasterEditionAccount?: Address<TAccountCollectionMasterEditionAccount>;
+  /** Collection Authority Record PDA */
+  collectionAuthorityRecord?: Address<TAccountCollectionAuthorityRecord>;
+};
+
+export async function getSetAndVerifySizedCollectionItemInstructionAsync<
+  TAccountMetadata extends string,
+  TAccountCollectionAuthority extends string,
+  TAccountPayer extends string,
+  TAccountUpdateAuthority extends string,
+  TAccountCollectionMint extends string,
+  TAccountCollection extends string,
+  TAccountCollectionMasterEditionAccount extends string,
+  TAccountCollectionAuthorityRecord extends string,
+  TProgramAddress extends Address = typeof TOKEN_METADATA_PROGRAM_ADDRESS,
+>(
+  input: SetAndVerifySizedCollectionItemAsyncInput<
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountUpdateAuthority,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >,
+  config?: { programAddress?: TProgramAddress },
+): Promise<
+  SetAndVerifySizedCollectionItemInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountUpdateAuthority,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >
+> {
+  // Program address.
+  const programAddress =
+    config?.programAddress ?? TOKEN_METADATA_PROGRAM_ADDRESS;
+
+  // Original accounts.
+  const originalAccounts = {
+    metadata: { value: input.metadata ?? null, isWritable: true },
+    collectionAuthority: {
+      value: input.collectionAuthority ?? null,
+      isWritable: false,
+    },
+    payer: { value: input.payer ?? null, isWritable: true },
+    updateAuthority: {
+      value: input.updateAuthority ?? null,
+      isWritable: false,
+    },
+    collectionMint: { value: input.collectionMint ?? null, isWritable: false },
+    collection: { value: input.collection ?? null, isWritable: true },
+    collectionMasterEditionAccount: {
+      value: input.collectionMasterEditionAccount ?? null,
+      isWritable: false,
+    },
+    collectionAuthorityRecord: {
+      value: input.collectionAuthorityRecord ?? null,
+      isWritable: false,
+    },
+  };
+  const accounts = originalAccounts as Record<
+    keyof typeof originalAccounts,
+    ResolvedInstructionAccount
+  >;
+
+  // Resolve default values.
+  if (!accounts.collection.value) {
+    accounts.collection.value = await findMetadataPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+  if (!accounts.collectionMasterEditionAccount.value) {
+    accounts.collectionMasterEditionAccount.value = await findMasterEditionPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+
+  const getAccountMeta = getAccountMetaFactory(programAddress, "omitted");
+  return Object.freeze({
+    accounts: [
+      getAccountMeta("metadata", accounts.metadata),
+      getAccountMeta("collectionAuthority", accounts.collectionAuthority),
+      getAccountMeta("payer", accounts.payer),
+      getAccountMeta("updateAuthority", accounts.updateAuthority),
+      getAccountMeta("collectionMint", accounts.collectionMint),
+      getAccountMeta("collection", accounts.collection),
+      getAccountMeta(
+        "collectionMasterEditionAccount",
+        accounts.collectionMasterEditionAccount,
+      ),
+      getAccountMeta(
+        "collectionAuthorityRecord",
+        accounts.collectionAuthorityRecord,
+      ),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
+    data: getSetAndVerifySizedCollectionItemInstructionDataEncoder().encode({}),
+    programAddress,
+  } as SetAndVerifySizedCollectionItemInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountUpdateAuthority,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >);
 }
 
 export type SetAndVerifySizedCollectionItemInput<

--- a/clients/token-metadata/src/generated/instructions/setCollectionSize.ts
+++ b/clients/token-metadata/src/generated/instructions/setCollectionSize.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  address,
   combineCodec,
   getStructDecoder,
   getStructEncoder,
@@ -32,8 +33,10 @@ import {
 } from "@solana/kit";
 import {
   getAccountMetaFactory,
+  getAddressFromResolvedInstructionAccount,
   type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findMetadataPda } from "../pdas/index.js";
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "../programs/index.js";
 import {
   getSetCollectionSizeArgsDecoder,
@@ -117,6 +120,109 @@ export function getSetCollectionSizeInstructionDataCodec(): FixedSizeCodec<
     getSetCollectionSizeInstructionDataEncoder(),
     getSetCollectionSizeInstructionDataDecoder(),
   );
+}
+
+export type SetCollectionSizeAsyncInput<
+  TAccountCollectionMetadata extends string = string,
+  TAccountCollectionAuthority extends string = string,
+  TAccountCollectionMint extends string = string,
+  TAccountCollectionAuthorityRecord extends string = string,
+> = {
+  /** Collection Metadata account */
+  collectionMetadata?: Address<TAccountCollectionMetadata>;
+  /** Collection Update authority */
+  collectionAuthority: TransactionSigner<TAccountCollectionAuthority>;
+  /** Mint of the Collection */
+  collectionMint: Address<TAccountCollectionMint>;
+  /** Collection Authority Record PDA */
+  collectionAuthorityRecord?: Address<TAccountCollectionAuthorityRecord>;
+  setCollectionSizeArgs: SetCollectionSizeInstructionDataArgs["setCollectionSizeArgs"];
+};
+
+export async function getSetCollectionSizeInstructionAsync<
+  TAccountCollectionMetadata extends string,
+  TAccountCollectionAuthority extends string,
+  TAccountCollectionMint extends string,
+  TAccountCollectionAuthorityRecord extends string,
+  TProgramAddress extends Address = typeof TOKEN_METADATA_PROGRAM_ADDRESS,
+>(
+  input: SetCollectionSizeAsyncInput<
+    TAccountCollectionMetadata,
+    TAccountCollectionAuthority,
+    TAccountCollectionMint,
+    TAccountCollectionAuthorityRecord
+  >,
+  config?: { programAddress?: TProgramAddress },
+): Promise<
+  SetCollectionSizeInstruction<
+    TProgramAddress,
+    TAccountCollectionMetadata,
+    TAccountCollectionAuthority,
+    TAccountCollectionMint,
+    TAccountCollectionAuthorityRecord
+  >
+> {
+  // Program address.
+  const programAddress =
+    config?.programAddress ?? TOKEN_METADATA_PROGRAM_ADDRESS;
+
+  // Original accounts.
+  const originalAccounts = {
+    collectionMetadata: {
+      value: input.collectionMetadata ?? null,
+      isWritable: true,
+    },
+    collectionAuthority: {
+      value: input.collectionAuthority ?? null,
+      isWritable: true,
+    },
+    collectionMint: { value: input.collectionMint ?? null, isWritable: false },
+    collectionAuthorityRecord: {
+      value: input.collectionAuthorityRecord ?? null,
+      isWritable: false,
+    },
+  };
+  const accounts = originalAccounts as Record<
+    keyof typeof originalAccounts,
+    ResolvedInstructionAccount
+  >;
+
+  // Original args.
+  const args = { ...input };
+
+  // Resolve default values.
+  if (!accounts.collectionMetadata.value) {
+    accounts.collectionMetadata.value = await findMetadataPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+
+  const getAccountMeta = getAccountMetaFactory(programAddress, "omitted");
+  return Object.freeze({
+    accounts: [
+      getAccountMeta("collectionMetadata", accounts.collectionMetadata),
+      getAccountMeta("collectionAuthority", accounts.collectionAuthority),
+      getAccountMeta("collectionMint", accounts.collectionMint),
+      getAccountMeta(
+        "collectionAuthorityRecord",
+        accounts.collectionAuthorityRecord,
+      ),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
+    data: getSetCollectionSizeInstructionDataEncoder().encode(
+      args as SetCollectionSizeInstructionDataArgs,
+    ),
+    programAddress,
+  } as SetCollectionSizeInstruction<
+    TProgramAddress,
+    TAccountCollectionMetadata,
+    TAccountCollectionAuthority,
+    TAccountCollectionMint,
+    TAccountCollectionAuthorityRecord
+  >);
 }
 
 export type SetCollectionSizeInput<

--- a/clients/token-metadata/src/generated/instructions/unverifyCollection.ts
+++ b/clients/token-metadata/src/generated/instructions/unverifyCollection.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  address,
   combineCodec,
   getStructDecoder,
   getStructEncoder,
@@ -32,8 +33,10 @@ import {
 } from "@solana/kit";
 import {
   getAccountMetaFactory,
+  getAddressFromResolvedInstructionAccount,
   type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findMasterEditionPda, findMetadataPda } from "../pdas/index.js";
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "../programs/index.js";
 
 export const UNVERIFY_COLLECTION_DISCRIMINATOR = 22;
@@ -109,6 +112,133 @@ export function getUnverifyCollectionInstructionDataCodec(): FixedSizeCodec<
     getUnverifyCollectionInstructionDataEncoder(),
     getUnverifyCollectionInstructionDataDecoder(),
   );
+}
+
+export type UnverifyCollectionAsyncInput<
+  TAccountMetadata extends string = string,
+  TAccountCollectionAuthority extends string = string,
+  TAccountCollectionMint extends string = string,
+  TAccountCollection extends string = string,
+  TAccountCollectionMasterEditionAccount extends string = string,
+  TAccountCollectionAuthorityRecord extends string = string,
+> = {
+  /** Metadata account */
+  metadata: Address<TAccountMetadata>;
+  /** Collection Authority */
+  collectionAuthority: TransactionSigner<TAccountCollectionAuthority>;
+  /** Mint of the Collection */
+  collectionMint: Address<TAccountCollectionMint>;
+  /** Metadata Account of the Collection */
+  collection?: Address<TAccountCollection>;
+  /** MasterEdition2 Account of the Collection Token */
+  collectionMasterEditionAccount?: Address<TAccountCollectionMasterEditionAccount>;
+  /** Collection Authority Record PDA */
+  collectionAuthorityRecord?: Address<TAccountCollectionAuthorityRecord>;
+};
+
+export async function getUnverifyCollectionInstructionAsync<
+  TAccountMetadata extends string,
+  TAccountCollectionAuthority extends string,
+  TAccountCollectionMint extends string,
+  TAccountCollection extends string,
+  TAccountCollectionMasterEditionAccount extends string,
+  TAccountCollectionAuthorityRecord extends string,
+  TProgramAddress extends Address = typeof TOKEN_METADATA_PROGRAM_ADDRESS,
+>(
+  input: UnverifyCollectionAsyncInput<
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >,
+  config?: { programAddress?: TProgramAddress },
+): Promise<
+  UnverifyCollectionInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >
+> {
+  // Program address.
+  const programAddress =
+    config?.programAddress ?? TOKEN_METADATA_PROGRAM_ADDRESS;
+
+  // Original accounts.
+  const originalAccounts = {
+    metadata: { value: input.metadata ?? null, isWritable: true },
+    collectionAuthority: {
+      value: input.collectionAuthority ?? null,
+      isWritable: true,
+    },
+    collectionMint: { value: input.collectionMint ?? null, isWritable: false },
+    collection: { value: input.collection ?? null, isWritable: false },
+    collectionMasterEditionAccount: {
+      value: input.collectionMasterEditionAccount ?? null,
+      isWritable: false,
+    },
+    collectionAuthorityRecord: {
+      value: input.collectionAuthorityRecord ?? null,
+      isWritable: false,
+    },
+  };
+  const accounts = originalAccounts as Record<
+    keyof typeof originalAccounts,
+    ResolvedInstructionAccount
+  >;
+
+  // Resolve default values.
+  if (!accounts.collection.value) {
+    accounts.collection.value = await findMetadataPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+  if (!accounts.collectionMasterEditionAccount.value) {
+    accounts.collectionMasterEditionAccount.value = await findMasterEditionPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+
+  const getAccountMeta = getAccountMetaFactory(programAddress, "omitted");
+  return Object.freeze({
+    accounts: [
+      getAccountMeta("metadata", accounts.metadata),
+      getAccountMeta("collectionAuthority", accounts.collectionAuthority),
+      getAccountMeta("collectionMint", accounts.collectionMint),
+      getAccountMeta("collection", accounts.collection),
+      getAccountMeta(
+        "collectionMasterEditionAccount",
+        accounts.collectionMasterEditionAccount,
+      ),
+      getAccountMeta(
+        "collectionAuthorityRecord",
+        accounts.collectionAuthorityRecord,
+      ),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
+    data: getUnverifyCollectionInstructionDataEncoder().encode({}),
+    programAddress,
+  } as UnverifyCollectionInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >);
 }
 
 export type UnverifyCollectionInput<

--- a/clients/token-metadata/src/generated/instructions/unverifySizedCollectionItem.ts
+++ b/clients/token-metadata/src/generated/instructions/unverifySizedCollectionItem.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  address,
   combineCodec,
   getStructDecoder,
   getStructEncoder,
@@ -33,8 +34,10 @@ import {
 } from "@solana/kit";
 import {
   getAccountMetaFactory,
+  getAddressFromResolvedInstructionAccount,
   type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findMasterEditionPda, findMetadataPda } from "../pdas/index.js";
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "../programs/index.js";
 
 export const UNVERIFY_SIZED_COLLECTION_ITEM_DISCRIMINATOR = 31;
@@ -120,6 +123,142 @@ export function getUnverifySizedCollectionItemInstructionDataCodec(): FixedSizeC
     getUnverifySizedCollectionItemInstructionDataEncoder(),
     getUnverifySizedCollectionItemInstructionDataDecoder(),
   );
+}
+
+export type UnverifySizedCollectionItemAsyncInput<
+  TAccountMetadata extends string = string,
+  TAccountCollectionAuthority extends string = string,
+  TAccountPayer extends string = string,
+  TAccountCollectionMint extends string = string,
+  TAccountCollection extends string = string,
+  TAccountCollectionMasterEditionAccount extends string = string,
+  TAccountCollectionAuthorityRecord extends string = string,
+> = {
+  /** Metadata account */
+  metadata: Address<TAccountMetadata>;
+  /** Collection Authority */
+  collectionAuthority: TransactionSigner<TAccountCollectionAuthority>;
+  /** payer */
+  payer: TransactionSigner<TAccountPayer>;
+  /** Mint of the Collection */
+  collectionMint: Address<TAccountCollectionMint>;
+  /** Metadata Account of the Collection */
+  collection?: Address<TAccountCollection>;
+  /** MasterEdition2 Account of the Collection Token */
+  collectionMasterEditionAccount?: Address<TAccountCollectionMasterEditionAccount>;
+  /** Collection Authority Record PDA */
+  collectionAuthorityRecord?: Address<TAccountCollectionAuthorityRecord>;
+};
+
+export async function getUnverifySizedCollectionItemInstructionAsync<
+  TAccountMetadata extends string,
+  TAccountCollectionAuthority extends string,
+  TAccountPayer extends string,
+  TAccountCollectionMint extends string,
+  TAccountCollection extends string,
+  TAccountCollectionMasterEditionAccount extends string,
+  TAccountCollectionAuthorityRecord extends string,
+  TProgramAddress extends Address = typeof TOKEN_METADATA_PROGRAM_ADDRESS,
+>(
+  input: UnverifySizedCollectionItemAsyncInput<
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >,
+  config?: { programAddress?: TProgramAddress },
+): Promise<
+  UnverifySizedCollectionItemInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >
+> {
+  // Program address.
+  const programAddress =
+    config?.programAddress ?? TOKEN_METADATA_PROGRAM_ADDRESS;
+
+  // Original accounts.
+  const originalAccounts = {
+    metadata: { value: input.metadata ?? null, isWritable: true },
+    collectionAuthority: {
+      value: input.collectionAuthority ?? null,
+      isWritable: false,
+    },
+    payer: { value: input.payer ?? null, isWritable: true },
+    collectionMint: { value: input.collectionMint ?? null, isWritable: false },
+    collection: { value: input.collection ?? null, isWritable: true },
+    collectionMasterEditionAccount: {
+      value: input.collectionMasterEditionAccount ?? null,
+      isWritable: false,
+    },
+    collectionAuthorityRecord: {
+      value: input.collectionAuthorityRecord ?? null,
+      isWritable: false,
+    },
+  };
+  const accounts = originalAccounts as Record<
+    keyof typeof originalAccounts,
+    ResolvedInstructionAccount
+  >;
+
+  // Resolve default values.
+  if (!accounts.collection.value) {
+    accounts.collection.value = await findMetadataPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+  if (!accounts.collectionMasterEditionAccount.value) {
+    accounts.collectionMasterEditionAccount.value = await findMasterEditionPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+
+  const getAccountMeta = getAccountMetaFactory(programAddress, "omitted");
+  return Object.freeze({
+    accounts: [
+      getAccountMeta("metadata", accounts.metadata),
+      getAccountMeta("collectionAuthority", accounts.collectionAuthority),
+      getAccountMeta("payer", accounts.payer),
+      getAccountMeta("collectionMint", accounts.collectionMint),
+      getAccountMeta("collection", accounts.collection),
+      getAccountMeta(
+        "collectionMasterEditionAccount",
+        accounts.collectionMasterEditionAccount,
+      ),
+      getAccountMeta(
+        "collectionAuthorityRecord",
+        accounts.collectionAuthorityRecord,
+      ),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
+    data: getUnverifySizedCollectionItemInstructionDataEncoder().encode({}),
+    programAddress,
+  } as UnverifySizedCollectionItemInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >);
 }
 
 export type UnverifySizedCollectionItemInput<

--- a/clients/token-metadata/src/generated/instructions/verifyCollection.ts
+++ b/clients/token-metadata/src/generated/instructions/verifyCollection.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  address,
   combineCodec,
   getStructDecoder,
   getStructEncoder,
@@ -32,8 +33,10 @@ import {
 } from "@solana/kit";
 import {
   getAccountMetaFactory,
+  getAddressFromResolvedInstructionAccount,
   type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findMasterEditionPda, findMetadataPda } from "../pdas/index.js";
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "../programs/index.js";
 
 export const VERIFY_COLLECTION_DISCRIMINATOR = 18;
@@ -114,6 +117,142 @@ export function getVerifyCollectionInstructionDataCodec(): FixedSizeCodec<
     getVerifyCollectionInstructionDataEncoder(),
     getVerifyCollectionInstructionDataDecoder(),
   );
+}
+
+export type VerifyCollectionAsyncInput<
+  TAccountMetadata extends string = string,
+  TAccountCollectionAuthority extends string = string,
+  TAccountPayer extends string = string,
+  TAccountCollectionMint extends string = string,
+  TAccountCollection extends string = string,
+  TAccountCollectionMasterEditionAccount extends string = string,
+  TAccountCollectionAuthorityRecord extends string = string,
+> = {
+  /** Metadata account */
+  metadata: Address<TAccountMetadata>;
+  /** Collection Update authority */
+  collectionAuthority: TransactionSigner<TAccountCollectionAuthority>;
+  /** payer */
+  payer: TransactionSigner<TAccountPayer>;
+  /** Mint of the Collection */
+  collectionMint: Address<TAccountCollectionMint>;
+  /** Metadata Account of the Collection */
+  collection?: Address<TAccountCollection>;
+  /** MasterEdition2 Account of the Collection Token */
+  collectionMasterEditionAccount?: Address<TAccountCollectionMasterEditionAccount>;
+  /** Collection Authority Record PDA */
+  collectionAuthorityRecord?: Address<TAccountCollectionAuthorityRecord>;
+};
+
+export async function getVerifyCollectionInstructionAsync<
+  TAccountMetadata extends string,
+  TAccountCollectionAuthority extends string,
+  TAccountPayer extends string,
+  TAccountCollectionMint extends string,
+  TAccountCollection extends string,
+  TAccountCollectionMasterEditionAccount extends string,
+  TAccountCollectionAuthorityRecord extends string,
+  TProgramAddress extends Address = typeof TOKEN_METADATA_PROGRAM_ADDRESS,
+>(
+  input: VerifyCollectionAsyncInput<
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >,
+  config?: { programAddress?: TProgramAddress },
+): Promise<
+  VerifyCollectionInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >
+> {
+  // Program address.
+  const programAddress =
+    config?.programAddress ?? TOKEN_METADATA_PROGRAM_ADDRESS;
+
+  // Original accounts.
+  const originalAccounts = {
+    metadata: { value: input.metadata ?? null, isWritable: true },
+    collectionAuthority: {
+      value: input.collectionAuthority ?? null,
+      isWritable: true,
+    },
+    payer: { value: input.payer ?? null, isWritable: true },
+    collectionMint: { value: input.collectionMint ?? null, isWritable: false },
+    collection: { value: input.collection ?? null, isWritable: false },
+    collectionMasterEditionAccount: {
+      value: input.collectionMasterEditionAccount ?? null,
+      isWritable: false,
+    },
+    collectionAuthorityRecord: {
+      value: input.collectionAuthorityRecord ?? null,
+      isWritable: false,
+    },
+  };
+  const accounts = originalAccounts as Record<
+    keyof typeof originalAccounts,
+    ResolvedInstructionAccount
+  >;
+
+  // Resolve default values.
+  if (!accounts.collection.value) {
+    accounts.collection.value = await findMetadataPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+  if (!accounts.collectionMasterEditionAccount.value) {
+    accounts.collectionMasterEditionAccount.value = await findMasterEditionPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+
+  const getAccountMeta = getAccountMetaFactory(programAddress, "omitted");
+  return Object.freeze({
+    accounts: [
+      getAccountMeta("metadata", accounts.metadata),
+      getAccountMeta("collectionAuthority", accounts.collectionAuthority),
+      getAccountMeta("payer", accounts.payer),
+      getAccountMeta("collectionMint", accounts.collectionMint),
+      getAccountMeta("collection", accounts.collection),
+      getAccountMeta(
+        "collectionMasterEditionAccount",
+        accounts.collectionMasterEditionAccount,
+      ),
+      getAccountMeta(
+        "collectionAuthorityRecord",
+        accounts.collectionAuthorityRecord,
+      ),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
+    data: getVerifyCollectionInstructionDataEncoder().encode({}),
+    programAddress,
+  } as VerifyCollectionInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >);
 }
 
 export type VerifyCollectionInput<

--- a/clients/token-metadata/src/generated/instructions/verifySizedCollectionItem.ts
+++ b/clients/token-metadata/src/generated/instructions/verifySizedCollectionItem.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  address,
   combineCodec,
   getStructDecoder,
   getStructEncoder,
@@ -33,8 +34,10 @@ import {
 } from "@solana/kit";
 import {
   getAccountMetaFactory,
+  getAddressFromResolvedInstructionAccount,
   type ResolvedInstructionAccount,
 } from "@solana/program-client-core";
+import { findMasterEditionPda, findMetadataPda } from "../pdas/index.js";
 import { TOKEN_METADATA_PROGRAM_ADDRESS } from "../programs/index.js";
 
 export const VERIFY_SIZED_COLLECTION_ITEM_DISCRIMINATOR = 30;
@@ -120,6 +123,142 @@ export function getVerifySizedCollectionItemInstructionDataCodec(): FixedSizeCod
     getVerifySizedCollectionItemInstructionDataEncoder(),
     getVerifySizedCollectionItemInstructionDataDecoder(),
   );
+}
+
+export type VerifySizedCollectionItemAsyncInput<
+  TAccountMetadata extends string = string,
+  TAccountCollectionAuthority extends string = string,
+  TAccountPayer extends string = string,
+  TAccountCollectionMint extends string = string,
+  TAccountCollection extends string = string,
+  TAccountCollectionMasterEditionAccount extends string = string,
+  TAccountCollectionAuthorityRecord extends string = string,
+> = {
+  /** Metadata account */
+  metadata: Address<TAccountMetadata>;
+  /** Collection Update authority */
+  collectionAuthority: TransactionSigner<TAccountCollectionAuthority>;
+  /** payer */
+  payer: TransactionSigner<TAccountPayer>;
+  /** Mint of the Collection */
+  collectionMint: Address<TAccountCollectionMint>;
+  /** Metadata Account of the Collection */
+  collection?: Address<TAccountCollection>;
+  /** MasterEdition2 Account of the Collection Token */
+  collectionMasterEditionAccount?: Address<TAccountCollectionMasterEditionAccount>;
+  /** Collection Authority Record PDA */
+  collectionAuthorityRecord?: Address<TAccountCollectionAuthorityRecord>;
+};
+
+export async function getVerifySizedCollectionItemInstructionAsync<
+  TAccountMetadata extends string,
+  TAccountCollectionAuthority extends string,
+  TAccountPayer extends string,
+  TAccountCollectionMint extends string,
+  TAccountCollection extends string,
+  TAccountCollectionMasterEditionAccount extends string,
+  TAccountCollectionAuthorityRecord extends string,
+  TProgramAddress extends Address = typeof TOKEN_METADATA_PROGRAM_ADDRESS,
+>(
+  input: VerifySizedCollectionItemAsyncInput<
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >,
+  config?: { programAddress?: TProgramAddress },
+): Promise<
+  VerifySizedCollectionItemInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >
+> {
+  // Program address.
+  const programAddress =
+    config?.programAddress ?? TOKEN_METADATA_PROGRAM_ADDRESS;
+
+  // Original accounts.
+  const originalAccounts = {
+    metadata: { value: input.metadata ?? null, isWritable: true },
+    collectionAuthority: {
+      value: input.collectionAuthority ?? null,
+      isWritable: false,
+    },
+    payer: { value: input.payer ?? null, isWritable: true },
+    collectionMint: { value: input.collectionMint ?? null, isWritable: false },
+    collection: { value: input.collection ?? null, isWritable: true },
+    collectionMasterEditionAccount: {
+      value: input.collectionMasterEditionAccount ?? null,
+      isWritable: false,
+    },
+    collectionAuthorityRecord: {
+      value: input.collectionAuthorityRecord ?? null,
+      isWritable: false,
+    },
+  };
+  const accounts = originalAccounts as Record<
+    keyof typeof originalAccounts,
+    ResolvedInstructionAccount
+  >;
+
+  // Resolve default values.
+  if (!accounts.collection.value) {
+    accounts.collection.value = await findMetadataPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+  if (!accounts.collectionMasterEditionAccount.value) {
+    accounts.collectionMasterEditionAccount.value = await findMasterEditionPda({
+      programId: address("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"),
+      mint: getAddressFromResolvedInstructionAccount(
+        "collectionMint",
+        accounts.collectionMint.value,
+      ),
+    });
+  }
+
+  const getAccountMeta = getAccountMetaFactory(programAddress, "omitted");
+  return Object.freeze({
+    accounts: [
+      getAccountMeta("metadata", accounts.metadata),
+      getAccountMeta("collectionAuthority", accounts.collectionAuthority),
+      getAccountMeta("payer", accounts.payer),
+      getAccountMeta("collectionMint", accounts.collectionMint),
+      getAccountMeta("collection", accounts.collection),
+      getAccountMeta(
+        "collectionMasterEditionAccount",
+        accounts.collectionMasterEditionAccount,
+      ),
+      getAccountMeta(
+        "collectionAuthorityRecord",
+        accounts.collectionAuthorityRecord,
+      ),
+    ].filter(<T>(x: T | undefined): x is T => x !== undefined),
+    data: getVerifySizedCollectionItemInstructionDataEncoder().encode({}),
+    programAddress,
+  } as VerifySizedCollectionItemInstruction<
+    TProgramAddress,
+    TAccountMetadata,
+    TAccountCollectionAuthority,
+    TAccountPayer,
+    TAccountCollectionMint,
+    TAccountCollection,
+    TAccountCollectionMasterEditionAccount,
+    TAccountCollectionAuthorityRecord
+  >);
 }
 
 export type VerifySizedCollectionItemInput<

--- a/clients/token-metadata/src/generated/programs/tokenMetadata.ts
+++ b/clients/token-metadata/src/generated/programs/tokenMetadata.ts
@@ -78,7 +78,7 @@ import {
 import {
   getApproveCollectionAuthorityInstructionAsync,
   getApproveUseAuthorityInstructionAsync,
-  getBubblegumSetCollectionSizeInstruction,
+  getBubblegumSetCollectionSizeInstructionAsync,
   getBurnEditionNftInstruction,
   getBurnInstructionAsync,
   getBurnNftInstructionAsync,
@@ -113,27 +113,27 @@ import {
   getRevokeCollectionAuthorityInstructionAsync,
   getRevokeInstructionAsync,
   getRevokeUseAuthorityInstructionAsync,
-  getSetAndVerifyCollectionInstruction,
-  getSetAndVerifySizedCollectionItemInstruction,
-  getSetCollectionSizeInstruction,
+  getSetAndVerifyCollectionInstructionAsync,
+  getSetAndVerifySizedCollectionItemInstructionAsync,
+  getSetCollectionSizeInstructionAsync,
   getSetTokenStandardInstructionAsync,
   getSignMetadataInstruction,
   getThawDelegatedAccountInstruction,
   getTransferInstructionAsync,
   getTransferOutOfEscrowInstruction,
   getUnlockInstructionAsync,
-  getUnverifyCollectionInstruction,
+  getUnverifyCollectionInstructionAsync,
   getUnverifyInstruction,
-  getUnverifySizedCollectionItemInstruction,
+  getUnverifySizedCollectionItemInstructionAsync,
   getUpdateInstructionAsync,
   getUpdateMetadataAccountInstruction,
   getUpdateMetadataAccountV2Instruction,
   getUpdatePrimarySaleHappenedViaTokenInstruction,
   getUseInstructionAsync,
   getUtilizeInstructionAsync,
-  getVerifyCollectionInstruction,
+  getVerifyCollectionInstructionAsync,
   getVerifyInstruction,
-  getVerifySizedCollectionItemInstruction,
+  getVerifySizedCollectionItemInstructionAsync,
   parseApproveCollectionAuthorityInstruction,
   parseApproveUseAuthorityInstruction,
   parseBubblegumSetCollectionSizeInstruction,
@@ -194,7 +194,7 @@ import {
   parseVerifySizedCollectionItemInstruction,
   type ApproveCollectionAuthorityAsyncInput,
   type ApproveUseAuthorityAsyncInput,
-  type BubblegumSetCollectionSizeInput,
+  type BubblegumSetCollectionSizeAsyncInput,
   type BurnAsyncInput,
   type BurnEditionNftInput,
   type BurnNftAsyncInput,
@@ -287,27 +287,27 @@ import {
   type RevokeAsyncInput,
   type RevokeCollectionAuthorityAsyncInput,
   type RevokeUseAuthorityAsyncInput,
-  type SetAndVerifyCollectionInput,
-  type SetAndVerifySizedCollectionItemInput,
-  type SetCollectionSizeInput,
+  type SetAndVerifyCollectionAsyncInput,
+  type SetAndVerifySizedCollectionItemAsyncInput,
+  type SetCollectionSizeAsyncInput,
   type SetTokenStandardAsyncInput,
   type SignMetadataInput,
   type ThawDelegatedAccountInput,
   type TransferAsyncInput,
   type TransferOutOfEscrowInput,
   type UnlockAsyncInput,
-  type UnverifyCollectionInput,
+  type UnverifyCollectionAsyncInput,
   type UnverifyInput,
-  type UnverifySizedCollectionItemInput,
+  type UnverifySizedCollectionItemAsyncInput,
   type UpdateAsyncInput,
   type UpdateMetadataAccountInput,
   type UpdateMetadataAccountV2Input,
   type UpdatePrimarySaleHappenedViaTokenInput,
   type UseAsyncInput,
   type UtilizeAsyncInput,
-  type VerifyCollectionInput,
+  type VerifyCollectionAsyncInput,
   type VerifyInput,
-  type VerifySizedCollectionItemInput,
+  type VerifySizedCollectionItemAsyncInput,
 } from "../instructions/index.js";
 import {
   findMasterEditionPda,
@@ -1317,8 +1317,8 @@ export type TokenMetadataPluginInstructions = {
   ) => ReturnType<typeof getCreateMasterEditionV3InstructionAsync> &
     SelfPlanAndSendFunctions;
   verifyCollection: (
-    input: MakeOptional<VerifyCollectionInput, "payer">,
-  ) => ReturnType<typeof getVerifyCollectionInstruction> &
+    input: MakeOptional<VerifyCollectionAsyncInput, "payer">,
+  ) => ReturnType<typeof getVerifyCollectionInstructionAsync> &
     SelfPlanAndSendFunctions;
   utilize: (
     input: UtilizeAsyncInput,
@@ -1332,8 +1332,8 @@ export type TokenMetadataPluginInstructions = {
   ) => ReturnType<typeof getRevokeUseAuthorityInstructionAsync> &
     SelfPlanAndSendFunctions;
   unverifyCollection: (
-    input: UnverifyCollectionInput,
-  ) => ReturnType<typeof getUnverifyCollectionInstruction> &
+    input: UnverifyCollectionAsyncInput,
+  ) => ReturnType<typeof getUnverifyCollectionInstructionAsync> &
     SelfPlanAndSendFunctions;
   approveCollectionAuthority: (
     input: MakeOptional<ApproveCollectionAuthorityAsyncInput, "payer">,
@@ -1344,8 +1344,8 @@ export type TokenMetadataPluginInstructions = {
   ) => ReturnType<typeof getRevokeCollectionAuthorityInstructionAsync> &
     SelfPlanAndSendFunctions;
   setAndVerifyCollection: (
-    input: MakeOptional<SetAndVerifyCollectionInput, "payer">,
-  ) => ReturnType<typeof getSetAndVerifyCollectionInstruction> &
+    input: MakeOptional<SetAndVerifyCollectionAsyncInput, "payer">,
+  ) => ReturnType<typeof getSetAndVerifyCollectionInstructionAsync> &
     SelfPlanAndSendFunctions;
   freezeDelegatedAccount: (
     input: FreezeDelegatedAccountInput,
@@ -1363,32 +1363,32 @@ export type TokenMetadataPluginInstructions = {
     input: BurnNftAsyncInput,
   ) => ReturnType<typeof getBurnNftInstructionAsync> & SelfPlanAndSendFunctions;
   verifySizedCollectionItem: (
-    input: MakeOptional<VerifySizedCollectionItemInput, "payer">,
-  ) => ReturnType<typeof getVerifySizedCollectionItemInstruction> &
+    input: MakeOptional<VerifySizedCollectionItemAsyncInput, "payer">,
+  ) => ReturnType<typeof getVerifySizedCollectionItemInstructionAsync> &
     SelfPlanAndSendFunctions;
   unverifySizedCollectionItem: (
-    input: MakeOptional<UnverifySizedCollectionItemInput, "payer">,
-  ) => ReturnType<typeof getUnverifySizedCollectionItemInstruction> &
+    input: MakeOptional<UnverifySizedCollectionItemAsyncInput, "payer">,
+  ) => ReturnType<typeof getUnverifySizedCollectionItemInstructionAsync> &
     SelfPlanAndSendFunctions;
   setAndVerifySizedCollectionItem: (
-    input: MakeOptional<SetAndVerifySizedCollectionItemInput, "payer">,
-  ) => ReturnType<typeof getSetAndVerifySizedCollectionItemInstruction> &
+    input: MakeOptional<SetAndVerifySizedCollectionItemAsyncInput, "payer">,
+  ) => ReturnType<typeof getSetAndVerifySizedCollectionItemInstructionAsync> &
     SelfPlanAndSendFunctions;
   createMetadataAccountV3: (
     input: MakeOptional<CreateMetadataAccountV3AsyncInput, "payer">,
   ) => ReturnType<typeof getCreateMetadataAccountV3InstructionAsync> &
     SelfPlanAndSendFunctions;
   setCollectionSize: (
-    input: SetCollectionSizeInput,
-  ) => ReturnType<typeof getSetCollectionSizeInstruction> &
+    input: SetCollectionSizeAsyncInput,
+  ) => ReturnType<typeof getSetCollectionSizeInstructionAsync> &
     SelfPlanAndSendFunctions;
   setTokenStandard: (
     input: SetTokenStandardAsyncInput,
   ) => ReturnType<typeof getSetTokenStandardInstructionAsync> &
     SelfPlanAndSendFunctions;
   bubblegumSetCollectionSize: (
-    input: BubblegumSetCollectionSizeInput,
-  ) => ReturnType<typeof getBubblegumSetCollectionSizeInstruction> &
+    input: BubblegumSetCollectionSizeAsyncInput,
+  ) => ReturnType<typeof getBubblegumSetCollectionSizeInstructionAsync> &
     SelfPlanAndSendFunctions;
   burnEditionNft: (
     input: BurnEditionNftInput,
@@ -1647,7 +1647,7 @@ export function tokenMetadataProgram() {
           verifyCollection: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getVerifyCollectionInstruction({
+              getVerifyCollectionInstructionAsync({
                 ...input,
                 payer: input.payer ?? client.payer,
               }),
@@ -1673,7 +1673,7 @@ export function tokenMetadataProgram() {
           unverifyCollection: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getUnverifyCollectionInstruction(input),
+              getUnverifyCollectionInstructionAsync(input),
             ),
           approveCollectionAuthority: (input) =>
             addSelfPlanAndSendFunctions(
@@ -1691,7 +1691,7 @@ export function tokenMetadataProgram() {
           setAndVerifyCollection: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getSetAndVerifyCollectionInstruction({
+              getSetAndVerifyCollectionInstructionAsync({
                 ...input,
                 payer: input.payer ?? client.payer,
               }),
@@ -1719,7 +1719,7 @@ export function tokenMetadataProgram() {
           verifySizedCollectionItem: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getVerifySizedCollectionItemInstruction({
+              getVerifySizedCollectionItemInstructionAsync({
                 ...input,
                 payer: input.payer ?? client.payer,
               }),
@@ -1727,7 +1727,7 @@ export function tokenMetadataProgram() {
           unverifySizedCollectionItem: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getUnverifySizedCollectionItemInstruction({
+              getUnverifySizedCollectionItemInstructionAsync({
                 ...input,
                 payer: input.payer ?? client.payer,
               }),
@@ -1735,7 +1735,7 @@ export function tokenMetadataProgram() {
           setAndVerifySizedCollectionItem: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getSetAndVerifySizedCollectionItemInstruction({
+              getSetAndVerifySizedCollectionItemInstructionAsync({
                 ...input,
                 payer: input.payer ?? client.payer,
               }),
@@ -1751,7 +1751,7 @@ export function tokenMetadataProgram() {
           setCollectionSize: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getSetCollectionSizeInstruction(input),
+              getSetCollectionSizeInstructionAsync(input),
             ),
           setTokenStandard: (input) =>
             addSelfPlanAndSendFunctions(
@@ -1761,7 +1761,7 @@ export function tokenMetadataProgram() {
           bubblegumSetCollectionSize: (input) =>
             addSelfPlanAndSendFunctions(
               client,
-              getBubblegumSetCollectionSizeInstruction(input),
+              getBubblegumSetCollectionSizeInstructionAsync(input),
             ),
           burnEditionNft: (input) =>
             addSelfPlanAndSendFunctions(


### PR DESCRIPTION
## Summary

Follow-up to #107. That PR made the tokenRecord PDA and transfer instruction complete (already on master). This one closes the remaining cleanly-derivable gap: the **collection** Metadata / master edition accounts, which are all derivable from a required `collectionMint` but were not being defaulted.

New defaults:
- `collection` → Metadata PDA of `collectionMint`
- `collectionMasterEditionAccount` → master edition PDA of `collectionMint`

across the collection (un)verification instructions: `verifyCollection`, `unverifyCollection`, `setAndVerifyCollection`, `verifySizedCollectionItem`, `unverifySizedCollectionItem`, `setAndVerifySizedCollectionItem`.

And:
- `collectionMetadata` → Metadata PDA of `collectionMint`

for `setCollectionSize` and `bubblegumSetCollectionSize`.

## Deliberately excluded

The unified `verify` / `unverify` instructions take an **optional** `collectionMint`, which cannot seed a PDA default (codegen rejects optional seed accounts) — so they're left to the caller.

## Notes

- Adding async PDA resolvers promotes these instructions to their `...Async` builder variants, same as transfer/mint in #107.
- Generated diff is clean and minimal (only the 8 affected instructions + the program identity map) — #107 already synced the client with the current oxc/renderer toolchain, so there's no incidental drift.

## Testing

- `bun run build` ✅
- `bun run lint` ✅
- `bun run test` ✅
- Added a minor changeset for `@macalinao/clients-token-metadata`