### PR TITLE
fix: re-enable isolatedDeclarations for spl-governance and spl-stake-pool

### DIFF
--- a/clients/spl-governance/tsconfig.json
+++ b/clients/spl-governance/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.base.json",
-  "compilerOptions": {
-    "isolatedDeclarations": false
-  }
+  "extends": "@macalinao/tsconfig/tsconfig.base.json"
 }

--- a/clients/spl-stake-pool/tsconfig.json
+++ b/clients/spl-stake-pool/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@macalinao/tsconfig/tsconfig.base.json",
-  "compilerOptions": {
-    "isolatedDeclarations": false
-  }
+  "extends": "@macalinao/tsconfig/tsconfig.base.json"
 }


### PR DESCRIPTION
## Summary

`clients/spl-governance` and `clients/spl-stake-pool` were the only two clients overriding `isolatedDeclarations: false`. The workaround is obsolete — this drops it so both inherit `true` from `@macalinao/tsconfig/tsconfig.base.json`, matching the other ten clients.

## Why the override existed

It was not present when either client was created. It landed in f12d786, the same commit that added `setAccountDiscriminatorFromFieldVisitor`. That visitor emitted one unannotated export per account:

```ts
export const REALM_V1_ACCOUNT_TYPE = GovernanceAccountType.RealmV1;
```

An exported const initialized from an imported enum member can't be typed from a single file, so it tripped `TS9013` across ~20 accounts per client. Disabling the flag was the quick unblock.

## Why it's safe now

The Codama renderer update in 4592662 now emits the explicit annotation:

```ts
export const REALM_V1_ACCOUNT_TYPE: GovernanceAccountType =
```

That removed the need for the override, but nobody deleted it.

## Verification

Forced `isolatedDeclarations: true` with a real `emitDeclarationOnly` run against both clients: **zero** `TS9xxx` errors. I sanity-checked the harness by injecting a deliberate violation, which correctly reported `TS9013`, so the zero is meaningful rather than the check silently not running.

On this branch:

- `bun run build` — 21/21 tasks (the 2 uncached tasks are exactly the changed clients)
- `bun run lint` — clean (oxlint + oxfmt)
- `bun run test` — 29/29 tasks

No changeset: build-config only, published output is unchanged.

## Unrelated pre-existing issue

Both clients fail a direct `tsc` type-check on an error that is present with or without this change:

```
error TS2724: '"@solana/kit"' has no exported member named 'ExtendedClient'.
```

This is not specific to these two — `ExtendedClient` is used across nearly every client (quarry, orca-whirlpools, mpl-bubblegum, meteora-damm-v2, …), so it looks like `@solana/kit` version skew rather than a codegen bug. It does not block the build or lint. Out of scope here, but worth a separate look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified TypeScript configuration for governance and stake pool components.
  * Standardized both components on the shared project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->