### PR TITLE
refactor(renderers-js-esm): drop dead post-processing patches

### DIFF
--- a/packages/codama-renderers-js-esm/src/render-esm-typescript-visitor.ts
+++ b/packages/codama-renderers-js-esm/src/render-esm-typescript-visitor.ts
@@ -102,18 +102,8 @@ export function renderESMTypeScriptVisitor(
 
     renderMap = mapRenderMapContent(renderMap, (code) => {
       const updated = code
-        // .replace(/= 0x([\da-f]+), \/\//g, "= 0x$1; //")
-        .replaceAll("process.env.NODE_ENV !== 'production'", "true")
-        .replaceAll(";;", ";")
-        // Add return type annotations for functions that return simple types
-        .replace(
-          /export const (\w+DISCRIMINATOR)\s*=\s*new Uint8Array\(/g,
-          "export const $1: ReadonlyUint8Array = new Uint8Array(",
-        )
-        .replace(
-          /export function (get\w+DiscriminatorBytes)\(\)\s*{/g,
-          "export function $1(): ReadonlyUint8Array {",
-        )
+        // Add the `.js` extension required by ESM resolution to relative
+        // re-exports and `from "."` imports.
         .replace(
           /(export\s+\*\s+from\s+['"])(\.\/[^'"]+?)(?<!\.(js|ts|mjs|cjs|json))(['"])/g,
           (_: string, prefix: string, importPath: string) =>


### PR DESCRIPTION
## What

`renderESMTypeScriptVisitor` post-processes the output of upstream `@codama/renderers-js` with a stack of string/regex patches. Upstream has moved on, so some of them no longer match anything. This removes the ones that are provably dead.

## How this was measured

Every patch was temporarily wrapped in a `track(name, before, after)` helper that increments a counter when the string actually changed, with the tally appended to a file per codegen process. Then `bun run codegen` was run at the repo root, regenerating all 12 clients, and the per-patch counters were aggregated.

Counts below are **files changed** by that patch, summed across all clients.

| # | Patch | Hits | Verdict |
|---|-------|------|---------|
| 1 | `index.ts`: `export * from "./x"` -> `"./x/index.js"` | 12 | **Kept** |
| 2 | `process.env.NODE_ENV !== 'production'` -> `true` | **0** | Removed |
| 3 | `;;` -> `;` | **0** | Removed |
| 4 | `<X>DISCRIMINATOR = new Uint8Array(` -> adds `: ReadonlyUint8Array` | **0** | Removed |
| 5 | `get<X>DiscriminatorBytes() {` -> adds `(): ReadonlyUint8Array` | **0** | Removed |
| 6 | `export * from "./x"` -> appends `.js` | 71 | **Kept** |
| 7 | `from "."` -> `from "./index.js"` | 145 | **Kept** |
| 8 | `*Seeds` inline-`type` fix on `pdas/index.js` imports | 47 | **Kept** |
| 9 | `injectInstructionDocs(...)` | 111 | **Kept** |
| 10 | commented-out `= 0x<hex>, //` replace | **0** | Removed |

Per-client breakdown (only non-zero entries):

```
mpl-token-auth-rules  p1:1  p6:6  p7:4   p9:4
voter-stake-registry  p1:1  p6:6  p7:4   p8:3
tribeca               p1:1  p6:6  p7:6   p8:7
spl-stake-pool        p1:1  p6:6  p7:5   p9:27
meteora-damm-v2       p1:1  p6:6  p7:12  p9:2
token-metadata        p1:1  p6:6  p7:20  p8:1
quarry                p1:1  p6:6         p8:10
kamino-lending        p1:1  p6:6  p7:9   p8:6
mpl-bubblegum         p1:1  p6:6  p7:4   p8:2   p9:36
orca-whirlpools       p1:1  p6:5  p7:2
spl-governance        p1:1  p6:6  p7:12  p8:18
mpl-core              p1:1  p6:6  p7:67  p9:42
```

## Why each removed patch is dead

- **Patch 2 (NODE_ENV)** — upstream now emits bracket access. Raw pre-format codegen output contains `if (process.env['NODE_ENV'] !== 'production') {`, which the dot-notation `replaceAll` cannot match. Note: this means the patch's original *intent* (folding the dev-only check to `true`) has silently not been happening. Re-implementing it against the new form would change generated output, so it is deliberately out of scope here — worth a follow-up if that behavior is still wanted.
- **Patch 3 (`;;`)** — zero generated files across all 12 clients contain a doubled semicolon.
- **Patches 4 and 5 (discriminator type annotations)** — upstream emits the annotations itself. Generated output already reads `export const SHORT_URL_DISCRIMINATOR: ReadonlyUint8Array = new Uint8Array([` and `export function getTransferDiscriminatorBytes(): ReadonlyUint8Array {`. This is the same class of staleness as the `isolatedDeclarations: false` overrides that the renderer update in 4592662 made obsolete.
- **Patch 10** — already commented out. It was temporarily re-enabled purely to measure it: 0 hits.

Patch 9 was also checked for the double-docblock risk (i.e. upstream having started rendering instruction docs itself). It has not — generated instruction builders carry exactly one JSDoc block, the injected one.

No zero-hit patch was kept. Everything retained has measured hits on the current client set.

## Verification

- `bun install` — ok
- `bun run build` — 21/21 tasks pass
- `bun run codegen` then `bun run format` — **`git diff --stat clients/` is empty; generated output is byte-identical to `master`**. (The formatting step is part of the baseline: raw codegen emits single quotes and no trailing newline, and the committed files are post-`oxfmt`. The same codegen+format sequence was run on the unmodified tree first to establish that it reproduces the committed output exactly.)
- `bun run build` again — pass
- `bun run lint` — oxlint clean, oxfmt clean
- `bun run test` — 29/29 tasks pass

All instrumentation was removed before verification; the diff is only the deletions.

No changeset added, since generated output is unchanged.

The pre-existing, unrelated `TS2724: '"@solana/kit"' has no exported member named 'ExtendedClient'` error was left alone.

## Summary by Sourcery

Enhancements:
- Simplify the ESM TypeScript renderer by dropping string/regex patches that no longer affect generated code.