### PR TITLE
docs: require a changeset on every new PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,8 @@ export default defineConfig({
 
 1. `bun run build` - Check for TypeScript errors
 2. `bun run lint:fix` - Fix linting and formatting issues
+3. `bun run changeset` - Record the version bump before opening a PR (see
+   [Changesets on Every PR](#changesets-on-every-pr))
 
 ### oxlint Configuration
 
@@ -276,6 +278,25 @@ GitHub Actions workflow runs on push/PR to main:
 2. Version packages: `bun run ci:version`
 3. Publish to npm: `bun run ci:publish`
 4. Changesets handle version bumping and changelog generation
+
+### Changesets on Every PR
+
+**Every new PR must include a changeset.** Releases are cut from the
+changesets on master, so a PR without one ships its changes with no version
+bump and no changelog entry.
+
+1. Run `bun run changeset`
+2. Select the package(s) the PR affects
+3. Choose the semver bump: `patch` for fixes and internals, `minor` for new
+   backwards-compatible features, `major` for breaking changes
+4. Write a summary aimed at consumers of the package — it becomes the
+   changelog entry
+5. Commit the generated file in `.changeset/` as part of the PR
+
+For changes with no effect on published output — docs, CI workflows, repo
+tooling — use `bun run changeset --empty` to record the deliberate decision,
+or say in the PR description why no changeset is needed. This is the
+exception; anything that changes what a package publishes needs a real bump.
 
 ## Package Structure Guidelines
 


### PR DESCRIPTION
Docs-only change. Touches `CLAUDE.md` and nothing else — no source, config, or workflow files.

## What this adds

A new **Changesets on Every PR** subsection under the existing *Publishing Workflow* section in `CLAUDE.md`, establishing the policy that **every new PR must include a changeset**. It covers the mechanics concisely:

- Run `bun run changeset`
- Select the affected package(s)
- Choose the semver bump — `patch` for fixes and internals, `minor` for backwards-compatible features, `major` for breaking changes
- Write the summary for package consumers, since it becomes the changelog entry
- Commit the generated `.changeset/` file with the PR

It also adds a third step to the existing *After Making Code Changes* checklist that points at the new section, so the policy is visible from the workflow block agents actually follow. The two spots cross-reference rather than restate each other.

## Documented exception

The repo genuinely has changes where a version bump is meaningless — pure docs edits, CI config, internal build config producing byte-identical published output. For those, the section documents using `bun run changeset --empty` or explaining in the PR description why none is needed. This is framed explicitly as the exception, not an escape hatch: the default remains "add a changeset," and anything that changes what a package publishes needs a real bump.

## Changeset for this PR

None included, and that is consistent with the policy text above rather than an exemption from it. This PR modifies only `CLAUDE.md`, which is not part of any published package — no package's output changes, so there is no version to bump. The section as written permits exactly this: an explicit note in the PR description in place of a changeset file. The task constraints for this change were also docs-only, which ruled out adding a file under `.changeset/`.

## Verification

`bun run lint` passes clean (`oxlint` + `oxfmt --check`, 1250 files). `oxfmt` ignores `**/*.md` via `.oxfmtrc.json` `ignorePatterns`, so `CLAUDE.md` is not reformatted by the formatter — confirmed the file is unchanged apart from the intended addition.

## Summary by Sourcery

Document the requirement that every new PR include an appropriate changeset and surface it in the publishing workflow checklist.

Documentation:
- Add a dedicated "Changesets on Every PR" subsection outlining when and how to create changesets and the documented exception for non-published changes.
- Update the "After Making Code Changes" checklist to include running changeset and reference the new changesets policy section.