### PR TITLE
feat: enable react/react-compiler lint rule

### DIFF
--- a/.changeset/lucky-pandas-shake.md
+++ b/.changeset/lucky-pandas-shake.md
@@ -1,0 +1,7 @@
+---
+---
+
+Tooling only: enable the `react/react-compiler` oxlint rule so React Compiler
+diagnostics (Rules of Hooks, refs during render, setState during render) are
+caught in CI. Only `.oxlintrc.json` changed; no published package output
+changes.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -71,6 +71,7 @@
     "no-underscore-dangle": "off",
     "no-await-in-loop": "off",
     "react/react-in-jsx-scope": "off",
+    "react/react-compiler": "error",
     "jsdoc/check-tag-names": "off",
     "import/no-unassigned-import": "off",
     "oxc/only-used-in-recursion": "off",


### PR DESCRIPTION
## What

Enables oxlint's React Compiler diagnostics repo-wide:

```json
"react/react-compiler": "error"
```

The rule lives under the already-enabled `react` plugin, so no `plugins` change was needed. It is **not** part of the `correctness` category, so it has to be turned on explicitly in the `rules` block of `.oxlintrc.json`.

Verified against the installed binary (oxlint 1.73.0) rather than assumed — `node_modules/oxlint/configuration_schema.json` defines `react/react-compiler` with an optional `{ reportAllBailouts?: boolean }` config, and oxlint rejects unknown rule names at config-parse time, so the config loading cleanly is itself proof the rule is registered.

## Violations found

**Zero.** The only React in this repo is `apps/docs/` (Next.js 15 + Fumadocs) — 7 `.tsx` files, 418 lines total, all server components. There are no `use client` directives and no hook calls at all, so there is nothing for the compiler rules to flag. No source files were changed.

To make sure the rule was actually running over `apps/docs` and not silently skipped, a temporary component that reads `ref.current` during render was dropped into `apps/docs/src` and the repo lint did flag it:

```
apps/docs/src/__probe.tsx:5:16: error react(react-compiler): Refs: Cannot access refs during render
```

The probe file was removed afterwards. Rules of Hooks and setState-during-render violations were confirmed to fire the same way.

## Verification

| Command | Result |
| --- | --- |
| `bun run build` | pass (21/21 tasks) |
| `bun run lint:fix` | pass, no files modified |
| `bun run lint` | pass, clean |
| `bun run test` | pass (30/30 tasks, 16 tests) |

## Notes

- `reportAllBailouts` is left at its default (`false`). Bailouts are places the compiler declined to optimize, not rule violations; turning it on would be a separate, noisier decision.
- Empty changeset added — this touches lint config only, and `apps/docs` is not published.

## Summary by Sourcery

Enable React Compiler lint diagnostics via oxlint and document the tooling-only change.

Enhancements:
- Enable the `react/react-compiler` oxlint rule to enforce React Compiler diagnostics during linting.

Chores:
- Add a tooling-only changeset documenting the new React Compiler lint rule with no published package output changes.